### PR TITLE
Allow command line connection options

### DIFF
--- a/src/Refurb/Cli.hs
+++ b/src/Refurb/Cli.hs
@@ -119,7 +119,6 @@ connectOpsParser = fileParser <|> paramsParser
     paramsParser = ConnectOpsParams
       <$> OA.strOption
             (  OA.long "host"
-            <> OA.short 'h'
             <> OA.metavar "DATABASE-HOST"
             <> OA.value "localhost"
             <> OA.help "Database host"
@@ -127,7 +126,6 @@ connectOpsParser = fileParser <|> paramsParser
             )
       <*> OA.option OA.auto
             (  OA.long "port"
-            <> OA.short 'p'
             <> OA.metavar "DATABASE-PORT"
             <> OA.value 5432
             <> OA.help "Database port"
@@ -135,7 +133,6 @@ connectOpsParser = fileParser <|> paramsParser
             )
       <*> OA.strOption
             (  OA.long "dbname"
-            <> OA.short 'd'
             <> OA.metavar "DATABASE-NAME"
             <> OA.value "postgres"
             <> OA.help "Database name"
@@ -143,7 +140,6 @@ connectOpsParser = fileParser <|> paramsParser
             )
       <*> OA.strOption
             (  OA.long "user"
-            <> OA.short 'u'
             <> OA.metavar "DATABASE-USER"
             <> OA.value "postgres"
             <> OA.help "Database user"

--- a/src/Refurb/Cli.hs
+++ b/src/Refurb/Cli.hs
@@ -4,6 +4,7 @@ module Refurb.Cli where
 
 import ClassyPrelude
 import Composite.Record ((:->)(Val))
+import Data.Word (Word16)
 import qualified Options.Applicative as OA
 import Refurb.Store (FQualifiedKey)
 
@@ -86,17 +87,69 @@ commandBackupParser =
     )
     ( OA.progDesc "Back up the database" )
 
+-- |Options for connecting to database.
+data ConnectOps
+  = ConnectOpsFile FilePath
+  -- ^Connect via a file
+  | ConnectOpsParams String Word16 String String
+  -- ^Connect via parameters - reads password from PGPASS
+
 -- |Structure holding the parsed command line arguments and options.
 data Opts = Opts
-  { debug      :: Bool
+  { debug    :: Bool
   -- ^Whether to turn on debug logging to the console
-  , colorize   :: Bool
+  , colorize :: Bool
   -- ^Whether to colorize console output
-  , configFile :: FilePath
-  -- ^The configuration file where (presumably) the database connection information is stored
-  , command    :: Command
+  , config   :: ConnectOps
+  -- ^See 'ConnectOps'
+  , command  :: Command
   -- ^Which command the user chose and the options for that command
   }
+
+connectOpsParser :: OA.Parser ConnectOps
+connectOpsParser = fileParser <|> paramsParser
+  where
+    fileParser = ConnectOpsFile
+      <$> OA.strOption
+            (  OA.long "config"
+            <> OA.short 'c'
+            <> OA.metavar "SERVER-CONFIG"
+            <> OA.help "Path to server config file to read database connection information from"
+            )
+    paramsParser = ConnectOpsParams
+      <$> OA.strOption
+            (  OA.long "host"
+            <> OA.short 'h'
+            <> OA.metavar "DATABASE-HOST"
+            <> OA.value "localhost"
+            <> OA.help "Database host"
+            <> OA.showDefault
+            )
+      <*> OA.option OA.auto
+            (  OA.long "port"
+            <> OA.short 'p'
+            <> OA.metavar "DATABASE-PORT"
+            <> OA.value 5432
+            <> OA.help "Database port"
+            <> OA.showDefault
+            )
+      <*> OA.strOption
+            (  OA.long "dbname"
+            <> OA.short 'd'
+            <> OA.metavar "DATABASE-NAME"
+            <> OA.value "postgres"
+            <> OA.help "Database name"
+            <> OA.showDefault
+            )
+      <*> OA.strOption
+            (  OA.long "user"
+            <> OA.short 'u'
+            <> OA.metavar "DATABASE-USER"
+            <> OA.value "postgres"
+            <> OA.help "Database user"
+            <> OA.showDefault
+            )
+
 
 -- |Parser for the command line arguments
 optsParser :: OA.ParserInfo Opts
@@ -111,12 +164,7 @@ optsParser =
                 <> OA.help "Turn on debug diagnostic logging"
                 )
           <*> (not <$> OA.switch (OA.long "no-color" <> OA.help "disable ANSI colorization"))
-          <*> OA.strOption
-                (  OA.long "config"
-                <> OA.short 'c'
-                <> OA.metavar "SERVER-CONFIG"
-                <> OA.help "Path to server config file to read database connection information from"
-                )
+          <*> connectOpsParser
           <*> OA.hsubparser
                 (  OA.command "migrate"        commandMigrateParser
                 <> OA.command "show-log"       commandShowLogParser


### PR DESCRIPTION
So that we don't have to always provide a config file, because that can be confusing. This also makes it so that if you DON'T specify a config file it uses the default connection parameters, which I think is a nice feature.

```bash
Usage: refurb-migrate [-d|--debug] [--no-color] 
                      [(-c|--config SERVER-CONFIG) | [--host DATABASE-HOST] 
                        [--port DATABASE-PORT] [--dbname DATABASE-NAME] 
                        [--user DATABASE-USER]] COMMAND

Available options:
  -h,--help                Show this help text
  -d,--debug               Turn on debug diagnostic logging
  --no-color               disable ANSI colorization
  -c,--config SERVER-CONFIG
                           Path to server config file to read database
                           connection information from
  --host DATABASE-HOST     Database host (default: "localhost")
  --port DATABASE-PORT     Database port (default: 5432)
  --dbname DATABASE-NAME   Database name (default: "postgres")
  --user DATABASE-USER     Database user (default: "postgres")

Available commands:
  migrate                  Apply migrations to the database, or see which ones
                           would be applied
  show-log                 Show migrations along with their status in the
                           database
  show-migration           Show status of and log details for a particular
                           migration
  backup                   Back up the database
```